### PR TITLE
fix: replace datetime.now() with timezone-aware datetime.now(timezone.utc)

### DIFF
--- a/examples/end_to_end_pipeline.py
+++ b/examples/end_to_end_pipeline.py
@@ -19,7 +19,7 @@ import numpy as np
 import pandas as pd
 import mne
 import json
-from datetime import datetime
+from datetime import datetime, timezone
 
 # Add project root to path
 project_root = Path(__file__).parent.parent
@@ -292,7 +292,7 @@ class EEGPipeline:
         # Create comprehensive report
         report = {
             'metadata': {
-                'analysis_timestamp': datetime.now().isoformat(),
+                'analysis_timestamp': datetime.now(timezone.utc).isoformat(),
                 'pipeline_version': '1.0.0',
                 'data_info': {
                     'n_channels': raw.info['nchan'],
@@ -337,7 +337,7 @@ class EEGPipeline:
             Complete processing report
         """
         if session_id is None:
-            session_id = f"session_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
+            session_id = f"session_{datetime.now(timezone.utc).strftime('%Y%m%d_%H%M%S')}"
         
         logger.info(f"Starting EEG processing for {file_path}")
         logger.info(f"Session ID: {session_id}")
@@ -383,7 +383,7 @@ class EEGPipeline:
                 'error': str(e),
                 'session_id': session_id,
                 'file_path': str(file_path),
-                'timestamp': datetime.now().isoformat()
+                'timestamp': datetime.now(timezone.utc).isoformat()
             }
             
             # Save error report

--- a/scripts/test_markdown_report.py
+++ b/scripts/test_markdown_report.py
@@ -3,7 +3,7 @@
 
 import sys
 from pathlib import Path
-from datetime import datetime
+from datetime import datetime, timezone
 
 # Add project root to path
 sys.path.insert(0, str(Path(__file__).parent.parent))
@@ -38,7 +38,7 @@ def main():
             'file_name': 'sample_eeg.edf',
             'duration_seconds': 600,
             'sampling_rate': 256,
-            'timestamp': datetime.now().isoformat()
+            'timestamp': datetime.now(timezone.utc).isoformat()
         }
     }
     

--- a/services/snippet_maker.py
+++ b/services/snippet_maker.py
@@ -12,7 +12,7 @@ import mne
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple, Union
 import logging
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 import json
 
 # Add reference repos to path
@@ -131,7 +131,7 @@ class EEGSnippetMaker:
                 'n_samples': snippet_data.shape[1],
                 'n_channels': snippet_data.shape[0],
                 'extraction_method': 'fixed_length',
-                'timestamp': datetime.now().isoformat()
+                'timestamp': datetime.now(timezone.utc).isoformat()
             }
             
             snippets.append(snippet)
@@ -208,7 +208,7 @@ class EEGSnippetMaker:
                 'n_samples': epoch.shape[1],
                 'n_channels': epoch.shape[0],
                 'extraction_method': 'event_based',
-                'timestamp': datetime.now().isoformat()
+                'timestamp': datetime.now(timezone.utc).isoformat()
             }
             
             snippets.append(snippet)
@@ -281,7 +281,7 @@ class EEGSnippetMaker:
                 'n_samples': snippet_data.shape[1],
                 'n_channels': snippet_data.shape[0],
                 'extraction_method': 'anomaly_based',
-                'timestamp': datetime.now().isoformat()
+                'timestamp': datetime.now(timezone.utc).isoformat()
             }
             
             snippets.append(snippet)
@@ -517,7 +517,7 @@ class EEGSnippetMaker:
                 'features_extracted': include_features and self.feature_extraction,
                 'eegpt_analysis': include_eegpt,
                 'tsfresh_available': TSFRESH_AVAILABLE,
-                'timestamp': datetime.now().isoformat()
+                'timestamp': datetime.now(timezone.utc).isoformat()
             }
         }
         

--- a/src/brain_go_brrr/visualization/markdown_report.py
+++ b/src/brain_go_brrr/visualization/markdown_report.py
@@ -4,7 +4,7 @@ Generates markdown reports that are easy to read and version control friendly.
 """
 
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
@@ -122,7 +122,7 @@ class MarkdownReportGenerator:
         lines.append(f"- **File**: {processing_info.get('file_name', 'Unknown')}")
         lines.append(f"- **Duration**: {processing_info.get('duration_seconds', 0):.1f} seconds")
         lines.append(f"- **Sampling Rate**: {processing_info.get('sampling_rate', 0)} Hz")
-        lines.append(f"- **Timestamp**: {processing_info.get('timestamp', datetime.now().isoformat())}")
+        lines.append(f"- **Timestamp**: {processing_info.get('timestamp', datetime.now(timezone.utc).isoformat())}")
 
         return "\n".join(lines)
 
@@ -235,7 +235,7 @@ class MarkdownReportGenerator:
     def _create_footer(self) -> str:
         """Create report footer."""
         lines = ["---"]
-        lines.append(f"*Generated on {datetime.now().strftime('%Y-%m-%d %H:%M:%S')} by Brain-Go-Brrr*")
+        lines.append(f"*Generated on {datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M:%S')} by Brain-Go-Brrr*")
         return "\n".join(lines)
 
 

--- a/src/brain_go_brrr/visualization/pdf_report.py
+++ b/src/brain_go_brrr/visualization/pdf_report.py
@@ -8,7 +8,7 @@ Generates professional PDF reports with:
 
 import io
 import logging
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any
 
 import matplotlib
@@ -66,7 +66,7 @@ class PDFReportGenerator:
             'Author': 'Brain-Go-Brrr',
             'Subject': 'EEG Analysis Results',
             'Creator': 'Brain-Go-Brrr v0.1.0',
-            'CreationDate': datetime.now()
+            'CreationDate': datetime.now(timezone.utc)
         }) as pdf:
             # Create main report page
             fig = self._create_main_page(results)
@@ -178,7 +178,7 @@ class PDFReportGenerator:
 
         # File info
         filename = processing_info.get('file_name', 'Unknown')
-        timestamp = processing_info.get('timestamp', datetime.now().isoformat())
+        timestamp = processing_info.get('timestamp', datetime.now(timezone.utc).isoformat())
 
         ax.text(0.5, 0.3, f'File: {filename}', ha='center', fontsize=10)
         ax.text(0.5, 0.1, f'Generated: {timestamp}', ha='center', fontsize=8)


### PR DESCRIPTION
This PR fixes datetime deprecation warnings by replacing `datetime.now()` with timezone-aware `datetime.now(timezone.utc)` across the codebase.

## Changes
- Updated imports to include `timezone` in 5 files
- Replaced 12 instances of `datetime.now()` with `datetime.now(timezone.utc)`
- Ensures compatibility with Python 3.12+ deprecation warnings

## Files Updated
- `services/snippet_maker.py` (4 locations)
- `scripts/test_markdown_report.py` (1 location)
- `examples/end_to_end_pipeline.py` (3 locations)
- `src/brain_go_brrr/visualization/pdf_report.py` (2 locations)
- `src/brain_go_brrr/visualization/markdown_report.py` (2 locations)

Closes #1

Generated with [Claude Code](https://claude.ai/code)